### PR TITLE
Add support for 'is not' operator

### DIFF
--- a/src/Condition/Condition.php
+++ b/src/Condition/Condition.php
@@ -18,7 +18,7 @@ class Condition extends DBFunction
      *
      * @var array
      */
-    private const VALID_OPERATORS = ['=', '<>', '!=', 'like', 'not like', '<', '>', '<=', '>=', 'is', 'in', 'not in'];
+    private const VALID_OPERATORS = ['=', '<>', '!=', 'like', 'not like', '<', '>', '<=', '>=', 'is', 'is not', 'in', 'not in'];
 
     /**
      * Operators that accept arrays as parameters.

--- a/workbench/BaseTest/BaseProjectionTest.php
+++ b/workbench/BaseTest/BaseProjectionTest.php
@@ -202,7 +202,8 @@ abstract class BaseProjectionTest extends BaseTest
 
     public function testCondition()
     {
-        $queryResult = DB::selectOne('select '.
+        $queryResult = DB::selectOne(
+            'select '.
             QE::condition(1, 1)->as('equal').','.
             QE::condition(1, '=', 1)->as('equal_2').','.
             QE::condition(2, '>', 1)->as('greater').','.

--- a/workbench/BaseTest/BaseProjectionTest.php
+++ b/workbench/BaseTest/BaseProjectionTest.php
@@ -216,7 +216,9 @@ abstract class BaseProjectionTest extends BaseTest
             QE::condition(1, '!=', 2)->as('not_equal_2').','.
             QE::condition('a', 'not like', 'b')->as('not_like').','.
             QE::condition('b', 'in', ['a', 'b', 'c', 'd'])->as('in').','.
-            QE::condition('e', 'not in', ['a', 'b', 'c', 'd'])->as('not_in'));
+            QE::condition('e', 'not in', ['a', 'b', 'c', 'd'])->as('not_in').','.
+            QE::condition(1, 'is not', null)->as('is_not')
+        );
 
         self::assertEquals(1, $queryResult->equal_2);
         self::assertEquals(1, $queryResult->equal);
@@ -232,6 +234,7 @@ abstract class BaseProjectionTest extends BaseTest
         self::assertEquals(1, $queryResult->not_like);
         self::assertEquals(1, $queryResult->in);
         self::assertEquals(1, $queryResult->not_in);
+        self::assertEquals(1, $queryResult->is_not);
     }
 
     public function testAddDate()

--- a/workbench/BaseTest/BaseTest.php
+++ b/workbench/BaseTest/BaseTest.php
@@ -56,11 +56,11 @@ abstract class BaseTest extends TestCase
                 'password' => 'my_password',
             ]);
             $config->set('database.connections.sqlsrv', [
-                'driver'   => 'sqlsrv',
-                'host'     => '127.0.0.1',
-                'database' => 'tempdb',
-                'username' => 'sa',
-                'password' => 'yourStrong(!)Password',
+                'driver'                   => 'sqlsrv',
+                'host'                     => '127.0.0.1',
+                'database'                 => 'tempdb',
+                'username'                 => 'sa',
+                'password'                 => 'yourStrong(!)Password',
                 'trust_server_certificate' => true,
             ]);
 

--- a/workbench/BaseTest/BaseTest.php
+++ b/workbench/BaseTest/BaseTest.php
@@ -61,6 +61,7 @@ abstract class BaseTest extends TestCase
                 'database' => 'tempdb',
                 'username' => 'sa',
                 'password' => 'yourStrong(!)Password',
+                'trust_server_certificate' => true,
             ]);
 
             $config->set('database.default', $this->getDatabaseEngine());


### PR DESCRIPTION
Hi Siavash,

I’ve been working on [Issue #6](https://github.com/SiavashBamshadnia/Laravel-Query-Enrich/issues/6), and I’ve added support for the ‘**is not**’ operator in the *`Condition`* class.

Additionally, I noticed that the CI is failing due to self-signed certificates used by `potatoqualitee/mssqlsuite`. The `sqlsrv` driver doesn't trust self-signed certificates by default, so I’ve enabled support for self-signed certificates in CI, as we don’t use publicly trusted certificates in our environment.

I hope this helps the project grow even more! 😊