### PR TITLE
Support `isNull` as a parameter for `case->when` method

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,6 +1,8 @@
 name: unittests
 
-on: [ push ]
+on:
+  push:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/docs/QE/Advanced/case.md
+++ b/docs/QE/Advanced/case.md
@@ -5,15 +5,152 @@ if-then-else statement in standard programming languages.
 
 ## Example Usage
 
+### Basic Usage
+
+In this example, we add a column named `price_category` to the query response.  
+Books with a price greater than `100` are marked as `expensive`, while all others are marked as `affordable`.
+
+```php
+use sbamtr\LaravelQueryEnrich\QE;
+
+$books = Book::query()
+    ->select(
+        QE::case()
+            ->when(QE::c('price'), '>', 100)->then('expensive')
+            ->else('affordable')
+        ->as('price_category')
+    )
+    ->get();
+```
+
+### Multiple cases
+
+In this example, we add a `price_category` column with multiple conditions:  
+- Books priced above `200` are marked as `too_expensive`.  
+- Books priced above `100` (but `< 200`) are marked as `expensive`.  
+- All other books are marked as `affordable`.  
+
 ```php
 use sbamtr\LaravelQueryEnrich\QE;
 use function sbamtr\LaravelQueryEnrich\c;
 
-$books = Book::select(
-    QE::case()
-        ->when(c('price'), '>', 100)->then('expensive')
-        ->when(QE::condition(50, '<', c('price')), QE::condition(c('price'), '<=', 100))->then('moderate')
-        ->else('affordable')
+$books = Book::query()
+    ->select(
+        QE::case()
+            ->when(c('price'), '>=', 200)->then('too_expensive')
+            ->when(c('price'), '>', 100)->then('expensive')
+            ->else('affordable')
         ->as('price_category')
-)->get();
+    )
+    ->get();
+```
+
+### Multiple conditions
+
+In this example, we add a `price_category` column with more detailed conditions:  
+- Books with a price greater than `100` are marked as `expensive`.  
+- Books with a price between `50` and `100` (inclusive) are marked as `moderate`.  
+- All other books are marked as `affordable`.  
+```php
+use sbamtr\LaravelQueryEnrich\QE;
+use function sbamtr\LaravelQueryEnrich\c;
+
+$books = Book::query()
+    ->select(
+        QE::case()
+            ->when(QE::c('price'), '>', 100)->then('expensive')
+
+            ->when(
+                QE::condition(50, '<', QE::c('price')),
+                QE::condition(QE::c('price'), '<=', 100)
+            )->then('moderate')
+
+            ->else('affordable')
+        ->as('price_category')
+    )
+    ->get();
+```
+
+### Advanced usage
+In this example, we create a report of user registrations grouped by day and user type.  
+
+- We use the [`date`](../Date/date.md) function to format the `created_at` field as `Y-m-d`.  
+- A `case` expression marks users as **real** if `legal_id` is `null`, or **legal** otherwise.  
+- The [`count`](../Numeric/count.md) function counts the users in each group.  
+
+This way, you get a daily breakdown showing how many real and legal users registered in the selected time range.
+
+
+```php
+use sbamtr\LaravelQueryEnrich\QE;
+use Carbon\Carbon;
+
+$from = Carbon::today()->startOfWeek();
+$until = Carbon::today();
+
+$statics = User::query()
+    ->select(
+        /**
+         * Convert `created_at` to `Y-m-d` format
+         */
+        QE::date(QE::c('created_at'))->as('date'),
+
+        /**
+         * Detect type of the user based on `legal_id` nullish.
+         */
+        QE::case()
+            ->when(QE::isNull(QE::c('legal_id')))->then('real')
+            ->else('legal')
+            ->as('type'),
+
+        /**
+         * Count each type values.
+         */
+        QE::count()->as('count')
+    )
+    ->whereBetween('created_at', [
+        $from->startOfDay(), $until->endOfDay()
+    ])
+    ->groupBy('date', 'type')
+    ->get()
+```
+Which results to:
+```json
+[
+    {
+        "date": "2025-02-01",
+        "type": "real",
+        "count": 8
+    },
+    {
+        "date": "2025-02-02",
+        "type": "real",
+        "count": 7
+    },
+    {
+        "date": "2025-02-03",
+        "type": "real",
+        "count": 7
+    },
+    {
+        "date": "2025-02-03",
+        "type": "legal",
+        "count": 2
+    },
+    {
+        "date": "2025-02-04",
+        "type": "real",
+        "count": 9
+    },
+    {
+        "date": "2025-02-05",
+        "type": "real",
+        "count": 5
+    },
+    {
+        "date": "2025-02-05",
+        "type": "legal",
+        "count": 1
+    }
+]
 ```

--- a/src/Condition/ConditionParser.php
+++ b/src/Condition/ConditionParser.php
@@ -2,6 +2,7 @@
 
 namespace sbamtr\LaravelQueryEnrich\Condition;
 
+use sbamtr\LaravelQueryEnrich\Advanced\IsNull;
 use sbamtr\LaravelQueryEnrich\Exception\InvalidArgumentException;
 use sbamtr\LaravelQueryEnrich\Raw;
 
@@ -14,21 +15,26 @@ class ConditionParser
     /**
      * Parses an array of conditions.
      *
-     * @param array $conditions An array of conditions.
+     * @param non-empty-array $conditions An array of conditions.
      *
      * @throws InvalidArgumentException If the input is invalid.
      *
      * @return Condition|ConditionChain|Raw Depending on the input, this method returns an instance of Condition, ConditionChain, or Raw.
      */
-    public static function parse(array $conditions): Condition|ConditionChain|Raw
+    public static function parse(array $conditions): Condition|ConditionChain|IsNull|Raw
     {
-        if ($conditions[0] instanceof Raw and count($conditions) === 1) {
-            return $conditions[0];
+        $count = count($conditions);
+        $condition = reset($conditions);
+
+        if ($count === 1 && $condition instanceof Raw || $condition instanceof IsNull) {
+            return $condition;
         }
-        if ($conditions[0] instanceof Condition) {
+
+        if ($condition instanceof Condition) {
             return new ConditionChain($conditions);
         }
-        if (count($conditions) === 2 || count($conditions) === 3) {
+
+        if ($count === 2 || $count === 3) {
             return new Condition(...$conditions);
         }
 

--- a/workbench/BaseTest/BaseTest.php
+++ b/workbench/BaseTest/BaseTest.php
@@ -13,13 +13,6 @@ abstract class BaseTest extends TestCase
 {
     use WithFaker;
 
-    public function __construct(string $name)
-    {
-        parent::__construct($name);
-
-        $this->setUpFaker();
-    }
-
     protected function getPackageProviders($app)
     {
         return ['sbamtr\\LaravelQueryEnrich\\QueryEnrichServiceProvider'];


### PR DESCRIPTION
First, sorry for being late. :)

This resolves #8.  

In addition, this PR includes a few other changes:  
- Removed the overridden `__construct` method from `PHPUnit\Framework\TestCase`, since it is marked as **final** in newer versions after [12.0.3](https://github.com/sebastianbergmann/phpunit/releases/tag/12.0.3) and make CI failed for PHP **8.3** and **8.4**. However, `Orchestra\Testbench\Concerns\Testing::setUpTheTestEnvironmentTraits()` already handles this, so the override is not needed .  
<img width="1468" height="139" alt="image" src="https://github.com/user-attachments/assets/e345ded1-3b07-43ac-8620-bbc964156408" />

- Added more examples for `case`, which I hope will be useful.  
- Added `workflow_dispatch` to GitHub Actions, so tests can also be run manually from the GitHub UI.  