### PR TITLE
Fix Passing a subquery to DBFunction as argument

### DIFF
--- a/src/DBFunction.php
+++ b/src/DBFunction.php
@@ -158,7 +158,7 @@ abstract class DBFunction extends Expression
             return $parameter->toSql();
         }
         if ($parameter instanceof EloquentBuilder || $parameter instanceof QueryBuilder) {
-            return $parameter->toSql();
+            return '('.$parameter->toRawSql().')';
         }
         if (is_array($parameter)) {
             $queryGrammar = DB::connection()->getQueryGrammar();


### PR DESCRIPTION
This PR fixes two issues:

1. When the argument of `DBFunction` is a subquery with placeholders, those placeholders were not being replaced, causing the generated raw expression to be invalid and leaving the placeholders untouched.
    I replaced `->toSql()` with `->toRawSql()` to address this.

2. It was impossible to use a subquery in a CASE WHEN expression. Wrapping the subquery in parentheses resolves this problem.
