### PR TITLE
fix: SQLite exists condition

### DIFF
--- a/src/Advanced/Exists.php
+++ b/src/Advanced/Exists.php
@@ -21,6 +21,6 @@ class Exists extends DBFunction
 
     protected function getQuery(): string
     {
-        return $this->getFunctionCallSql('exists', [$this->query]);
+        return 'exists '.$this->escape($this->query);
     }
 }


### PR DESCRIPTION
[EXISTS](https://www.sqlite.org/lang_expr.html#the_exists_operator) actually is not a function, shouldn't be treated as one.